### PR TITLE
Rename repo to topological_inventory-openshift in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://travis-ci.org/ManageIQ/topological_inventory-collector-openshift.svg?branch=master)](https://travis-ci.org/ManageIQ/topological_inventory-collector-openshift))
-[![Maintainability](https://api.codeclimate.com/v1/badges/fc6eda966102ef7b319d/maintainability)](https://codeclimate.com/github/ManageIQ/topological_inventory-collector-openshift/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/fc6eda966102ef7b319d/test_coverage)](https://codeclimate.com/github/ManageIQ/topological_inventory-collector-openshift/test_coverage)
-[![Security](https://hakiri.io/github/ManageIQ/topological_inventory-collector-openshift/master.svg)](https://hakiri.io/github/ManageIQ/topological_inventory-collector-openshift/master)
+[![Build Status](https://travis-ci.org/ManageIQ/topological_inventory-openshift.svg?branch=master)](https://travis-ci.org/ManageIQ/topological_inventory-openshift))
+[![Maintainability](https://api.codeclimate.com/v1/badges/fc6eda966102ef7b319d/maintainability)](https://codeclimate.com/github/ManageIQ/topological_inventory-openshift/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/fc6eda966102ef7b319d/test_coverage)](https://codeclimate.com/github/ManageIQ/topological_inventory-openshift/test_coverage)
+[![Security](https://hakiri.io/github/ManageIQ/topological_inventory-openshift/master.svg)](https://hakiri.io/github/ManageIQ/topological_inventory-openshift/master)
 ## License
 
 This project is available as open source under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Update the repo name in the badges in the README

- [x] Travis repo needs to be enabled
- [ ] Codeclimate repo needs to be enabled
- [ ] Hakiri repo needs to be enabled