### PR TITLE
Collect external url for service instance

### DIFF
--- a/lib/topological_inventory/openshift/parser/service_instance.rb
+++ b/lib/topological_inventory/openshift/parser/service_instance.rb
@@ -13,12 +13,18 @@ module TopologicalInventory::Openshift
         service_offering = lazy_find(:service_offerings, :source_ref => cluster_service_class_name) if cluster_service_class_name
         service_plan     = lazy_find(:service_plans, :source_ref => cluster_service_plan_name) if cluster_service_plan_name
 
+        name      = service_instance.metadata.name
+        namespace = service_instance.metadata.namespace
+        url       = "https://#{self.openshift_host}:#{self.openshift_port}"\
+                    "/console/project/#{namespace}/browse/service-instances/#{name}?tab=details"
+
         service_instance = collections.service_instances.build(
           :source_ref        => service_instance.spec.externalID,
-          :name              => service_instance.spec.externalName,
+          :name              => name,
           :source_created_at => service_instance.metadata.creationTimestamp,
           :service_offering  => service_offering,
           :service_plan      => service_plan,
+          :external_url      => url
         )
 
         service_instance


### PR DESCRIPTION
Fixing also service instance name, that was nil in all cases.

Depends on:
- [x] https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/30﻿