### PR TITLE
Add log message

### DIFF
--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -72,6 +72,8 @@ module TopologicalInventory
 
           update_task(task_id, :state => "completed", :status => status, :context => context)
         rescue StandardError => err
+          logger.error("Exception while ordering #{err}")
+          logger.error(err.backtrace.join("\n"))
           update_task(task_id, :state => "completed", :status => "error", :context => {:error => err.to_s})
         end
 


### PR DESCRIPTION
During debugging a provision failure there is not enough logging information when failures happen.

Fixes #50 
