### PR TITLE
Manually ack messages after ordering then perform post_provision in a thread

### DIFF
--- a/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
@@ -32,14 +32,11 @@ module TopologicalInventory
             connection.create_service_instance(payload)
           end
 
-          def wait_for_provision_complete(service_instance)
+          def wait_for_provision_complete(name, namespace)
             loop do
               sleep(sleep_poll)
 
-              service_instance = connection.get_service_instance(
-                service_instance.metadata.name,
-                service_instance.metadata.namespace
-              )
+              service_instance = connection.get_service_instance(name, namespace)
 
               condition = service_instance.status.conditions.first
               logger.info("#{service_instance.metadata.name}: message [#{condition&.message}] status [#{condition&.status}] reason [#{condition&.reason}]")

--- a/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
@@ -74,7 +74,7 @@ module TopologicalInventory
           end
 
           def connection
-            @connection ||= connection_manager.connect(
+            Thread.current[:kubernetes_connection] ||= connection_manager.connect(
               "servicecatalog", :host => default_endpoint.host, :token => authentication.password, :verify_ssl => verify_ssl_mode
             )
           end

--- a/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
@@ -28,17 +28,24 @@ module TopologicalInventory
           end
 
           def order_service_plan(plan_name, service_offering_name, additional_parameters)
-            connection = connection_manager.connect(
-              "servicecatalog", :host => default_endpoint.host, :token => authentication.password, :verify_ssl => verify_ssl_mode
-            )
-
             payload = build_payload(plan_name, service_offering_name, additional_parameters)
+            connection.create_service_instance(payload)
+          end
 
-            service_instance = connection.create_service_instance(payload)
+          def wait_for_provision_complete(service_instance)
+            loop do
+              sleep(sleep_poll)
 
-            logger.info("Waiting for #{service_instance.metadata.name} to provision...")
-            service_instance = wait_for_provision_complete(connection, service_instance)
-            logger.info("Waiting for #{service_instance.metadata.name} to provision...Complete")
+              service_instance = connection.get_service_instance(
+                service_instance.metadata.name,
+                service_instance.metadata.namespace
+              )
+
+              condition = service_instance.status.conditions.first
+              logger.info("#{service_instance.metadata.name}: message [#{condition&.message}] status [#{condition&.status}] reason [#{condition&.reason}]")
+
+              break unless service_instance_provisioning?(service_instance)
+            end
 
             service_instance
           end
@@ -64,27 +71,15 @@ module TopologicalInventory
             }
           end
 
-          def wait_for_provision_complete(connection, service_instance)
-            loop do
-              sleep(sleep_poll)
-
-              service_instance = connection.get_service_instance(
-                service_instance.metadata.name,
-                service_instance.metadata.namespace
-              )
-
-              condition = service_instance.status.conditions.first
-              logger.info("#{service_instance.metadata.name}: message [#{condition&.message}] status [#{condition&.status}] reason [#{condition&.reason}]")
-
-              break unless service_instance_provisioning?(service_instance)
-            end
-
-            service_instance
-          end
-
           def service_instance_provisioning?(service_instance)
             reason = service_instance.status.conditions.first&.reason
             %w[Provisioning ProvisionRequestInFlight].include?(reason)
+          end
+
+          def connection
+            @connection ||= connection_manager.connect(
+              "servicecatalog", :host => default_endpoint.host, :token => authentication.password, :verify_ssl => verify_ssl_mode
+            )
           end
 
           def verify_ssl_mode

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -10,7 +10,6 @@ module TopologicalInventory
         include Logging
 
         def initialize(messaging_client_opts = {})
-          self.api_client            = TopologicalInventoryApiClient::DefaultApi.new
           self.messaging_client_opts = default_messaging_opts.merge(messaging_client_opts)
           self.sleep_poll            = 10   # seconds
           self.poll_timeout          = 1800 # seconds
@@ -36,7 +35,7 @@ module TopologicalInventory
 
         private
 
-        attr_accessor :messaging_client_opts, :client, :api_client, :sleep_poll, :poll_timeout
+        attr_accessor :messaging_client_opts, :client, :sleep_poll, :poll_timeout
 
         def process_message(client, msg)
           logger.info("Processing #{msg.message} with msg: #{msg.payload}")
@@ -159,6 +158,10 @@ module TopologicalInventory
           end
 
           service_instance
+        end
+
+        def api_client
+          Thread.current[:topological_inventory_api_client] ||= TopologicalInventoryApiClient::DefaultApi.new
         end
 
         def queue_opts

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -62,7 +62,11 @@ module TopologicalInventory
             service_plan.name, service_offering.name, order_params
           )
           client.ack(msg.ack_ref)
-          poll_order_complete(task_id, source_id, service_instance)
+
+          name      = service_instance.metadata.name
+          namespace = service_instance.metadata.namespace
+          poll_order_complete(task_id, source_id, name, namespace)
+
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...Complete")
         rescue StandardError => err
           logger.error("Exception while ordering #{err}")
@@ -75,14 +79,20 @@ module TopologicalInventory
           api_client.update_task(task_id, task)
         end
 
-        def poll_order_complete(task_id, source_id, service_instance)
+        def poll_order_complete(task_id, source_id, service_instance_name, service_instance_namespace)
           catalog_client = Core::ServiceCatalogClient.new(source_id)
-          catalog_client.wait_for_provision_complete(service_instance)
+          service_instance = catalog_client.wait_for_provision_complete(
+            service_instance_name, service_instance_namespace
+          )
 
           context = svc_instance_context_with_url(source_id, service_instance)
           status  = provisioning_status(service_instance)
 
           update_task(task_id, :state => "completed", :status => status, :context => context)
+        rescue StandardError => err
+          logger.error("Exception while ordering #{err}")
+          logger.error(err.backtrace.join("\n"))
+          update_task(task_id, :state => "completed", :status => "error", :context => {:error => err.to_s})
         end
 
         def svc_instance_context_with_url(source_id, service_instance)

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -57,9 +57,11 @@ module TopologicalInventory
 
           catalog_client = Core::ServiceCatalogClient.new(source_id)
 
+          logger.info("Ordering #{service_offering.name} #{service_plan.name}...")
           service_instance = catalog_client.order_service_plan(
             service_plan.name, service_offering.name, order_params
           )
+          logger.info("Ordering #{service_offering.name} #{service_plan.name}...Complete")
 
           poll_order_complete_thread(task_id, source_id, service_instance)
         rescue StandardError => err
@@ -81,10 +83,12 @@ module TopologicalInventory
         end
 
         def poll_order_complete(task_id, source_id, service_instance_name, service_instance_namespace)
+          logger.info("Waiting for service [#{service_instance_name}] to provision...")
           catalog_client = Core::ServiceCatalogClient.new(source_id)
           service_instance = catalog_client.wait_for_provision_complete(
             service_instance_name, service_instance_namespace
           )
+          logger.info("Waiting for service [#{service_instance_name}] to provision...Complete")
 
           context = svc_instance_context_with_url(source_id, service_instance)
           status  = provisioning_status(service_instance)

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -62,7 +62,7 @@ module TopologicalInventory
             service_plan.name, service_offering.name, order_params
           )
           client.ack(msg.ack_ref)
-          poll_order_complete(task_id, source_id, service_instance, service_offering, service_plan)
+          poll_order_complete(task_id, source_id, service_instance)
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...Complete")
         rescue StandardError => err
           logger.error("Exception while ordering #{err}")
@@ -75,7 +75,7 @@ module TopologicalInventory
           api_client.update_task(task_id, task)
         end
 
-        def poll_order_complete(task_id, source_id, service_instance, service_offering, service_plan)
+        def poll_order_complete(task_id, source_id, service_instance)
           catalog_client = Core::ServiceCatalogClient.new(source_id)
           catalog_client.wait_for_provision_complete(service_instance)
 

--- a/spec/topological_inventory/openshift/operations/worker_spec.rb
+++ b/spec/topological_inventory/openshift/operations/worker_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Worker do
     let(:service_instance) do
       Kubeclient::Resource.new(
         :metadata => {
-          :uid => "af01c63c-e479-4190-8054-9c5ba2e9ec81"
+          :name      => "my_service",
+          :namespace => "default",
+          :uid       => "af01c63c-e479-4190-8054-9c5ba2e9ec81"
         },
         :status   => {
           :conditions => [
@@ -76,14 +78,14 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Worker do
       ).to receive(:new).with(source.id).and_return(service_catalog_client)
 
       allow(service_catalog_client).to receive(:order_service_plan).and_return(service_instance)
-      allow(service_catalog_client).to receive(:wait_for_provision_complete)
+      allow(service_catalog_client).to receive(:wait_for_provision_complete).and_return(service_instance)
 
       stub_request(:patch, task_url).with(:headers => headers)
     end
 
     it "orders the service via the service catalog client" do
       expect(service_catalog_client).to receive(:order_service_plan).with("plan_name", "service_offering", "order_params")
-      expect(service_catalog_client).to receive(:wait_for_provision_complete).with(service_instance)
+      expect(service_catalog_client).to receive(:wait_for_provision_complete).with(service_instance.metadata.name, service_instance.metadata.namespace)
       described_class.new.run
     end
 


### PR DESCRIPTION
Auto-ack will only ack messages at the end of the batch, rather we can
manually ack the message when the provision request is submitted.