### PR TITLE
Fix an undefined variable error ordering a service

### DIFF
--- a/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
@@ -33,6 +33,8 @@ module TopologicalInventory
           end
 
           def wait_for_provision_complete(name, namespace)
+            service_instance = nil
+
             loop do
               sleep(sleep_poll)
 


### PR DESCRIPTION
```
Exception while ordering undefined local variable or method `service_instance'
for #<TopologicalInventory::Openshift::Operations::Core::ServiceCatalogClient:0x000000000279cd70>
Did you mean?  service_instance_provisioning?
```