### PR TITLE
Pull out operation processing into its own class

### DIFF
--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -1,0 +1,151 @@
+require "topological_inventory/openshift/logging"
+require "topological_inventory/openshift/operations/core/service_catalog_client"
+
+module TopologicalInventory
+  module Openshift
+    module Operations
+      class Processor
+        include Logging
+
+        def initialize(model, method, payload)
+          self.model   = model
+          self.method  = method
+          self.payload = payload
+        end
+
+        def process
+          logger.info("Processing #{model}##{method} [#{payload}]...")
+          order_service(payload)
+          logger.info("Processing #{model}##{method} [#{payload}]...Complete")
+        end
+
+        private
+
+        attr_accessor :model, :method, :payload
+
+        def order_service(payload)
+          task_id, service_plan_id, order_params = payload.values_at("task_id", "service_plan_id", "order_params")
+
+          service_plan     = api_client.show_service_plan(service_plan_id)
+          service_offering = api_client.show_service_offering(service_plan.service_offering_id)
+          source_id        = service_plan.source_id
+
+          catalog_client = Core::ServiceCatalogClient.new(source_id)
+
+          logger.info("Ordering #{service_offering.name} #{service_plan.name}...")
+          service_instance = catalog_client.order_service_plan(
+            service_plan.name, service_offering.name, order_params
+          )
+          logger.info("Ordering #{service_offering.name} #{service_plan.name}...Complete")
+
+          poll_order_complete_thread(task_id, source_id, service_instance)
+        rescue StandardError => err
+          logger.error("Exception while ordering #{err}")
+          logger.error(err.backtrace.join("\n"))
+          update_task(task_id, :state => "completed", :status => "error", :context => {:error => err.to_s})
+        end
+
+        def update_task(task_id, state:, status:, context:)
+          task = TopologicalInventoryApiClient::Task.new("state" => state, "status" => status, "context" => context.to_json)
+          api_client.update_task(task_id, task)
+        end
+
+        def poll_order_complete_thread(task_id, source_id, service_instance)
+          service_instance_name      = service_instance.metadata.name
+          service_instance_namespace = service_instance.metadata.namespace
+
+          Thread.new { poll_order_complete(task_id, source_id, service_instance_name, service_instance_namespace) }
+        end
+
+        def poll_order_complete(task_id, source_id, service_instance_name, service_instance_namespace)
+          logger.info("Waiting for service [#{service_instance_name}] to provision...")
+          catalog_client = Core::ServiceCatalogClient.new(source_id)
+          service_instance = catalog_client.wait_for_provision_complete(
+            service_instance_name, service_instance_namespace
+          )
+          logger.info("Waiting for service [#{service_instance_name}] to provision...Complete")
+
+          context = svc_instance_context_with_url(source_id, service_instance)
+          status  = provisioning_status(service_instance)
+
+          update_task(task_id, :state => "completed", :status => status, :context => context)
+        rescue StandardError => err
+          logger.error("Exception while ordering #{err}")
+          logger.error(err.backtrace.join("\n"))
+          update_task(task_id, :state => "completed", :status => "error", :context => {:error => err.to_s})
+        end
+
+        def svc_instance_context_with_url(source_id, service_instance)
+          context = {
+            :service_instance => {
+              :source_id  => source_id,
+              :source_ref => service_instance.spec&.externalID
+            }
+          }
+
+          if provisioning_status(service_instance) == "ok"
+            url = svc_instance_url(source_id, service_instance)
+            context[:service_instance][:url] = url if url.present?
+          end
+
+          context
+        end
+
+        def svc_instance_url(source_id, service_instance)
+          svc_instance = svc_instance_by_source_ref(source_id, service_instance.spec&.externalID)
+          return if svc_instance.nil?
+
+          rest_api_path = '/service_instances/{id}'.sub('{' + 'id' + '}', svc_instance&.id.to_s)
+          api_client.api_client.build_request(:GET, rest_api_path).url
+        end
+
+        def provisioning_status(service_instance)
+          reason = service_instance.status.conditions.first&.reason
+          reason == "ProvisionedSuccessfully" ? "ok" : "error"
+        end
+
+        # Current API client doesn't support source_id and source_ref filtering
+        # This is modified version of api_client.list_service_instances
+        def svc_instance_by_source_ref(source_id, source_ref)
+          sleep_poll   = 10
+          poll_timeout = 1800
+
+          api = api_client.api_client
+
+          header_params = { 'Accept' => api.select_header_accept(['application/json']) }
+          query_params = { :'source_id' => source_id, :'source_ref' => source_ref }
+
+          count = 0
+          timeout_count = poll_timeout / sleep_poll
+
+          service_instance = nil
+          loop do
+            data, status_code, headers = api.call_api(:GET, "/service_instances",
+                                                      :header_params => header_params,
+                                                      :query_params  => query_params,
+                                                      :form_params   => {},
+                                                      :body          => nil,
+                                                      :auth_names    => ['UserSecurity'],
+                                                      :return_type   => 'ServiceInstancesCollection')
+
+            service_instance = data.data&.first if data.meta.count > 0
+            break if service_instance.present?
+
+            break if (count += 1) >= timeout_count
+            sleep(sleep_poll)
+          end
+
+          if service_instance.nil?
+            logger.error("Failed to find service_instance by source_id [#{source_id}] source_ref [#{source_ref}]")
+          end
+
+          service_instance
+        end
+
+        def api_client
+          Thread.current[:api_client] ||= TopologicalInventoryApiClient::DefaultApi.new
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -11,162 +11,31 @@ module TopologicalInventory
 
         def initialize(messaging_client_opts = {})
           self.messaging_client_opts = default_messaging_opts.merge(messaging_client_opts)
-          self.sleep_poll            = 10   # seconds
-          self.poll_timeout          = 1800 # seconds
         end
 
         def run
           # Open a connection to the messaging service
-          self.client = ManageIQ::Messaging::Client.open(messaging_client_opts)
+          client = ManageIQ::Messaging::Client.open(messaging_client_opts)
 
           logger.info("Topological Inventory Openshift Operations worker started...")
 
           client.subscribe_messages(queue_opts) do |messages|
-            messages.each { |msg| process_message(client, msg) }
+            messages.each do |message|
+              model, method = message.message.split(".")
+
+              processor = Processor.new(model, method, message.payload)
+              processor.process
+
+              client.ack(message.ack_ref)
+            end
           end
         ensure
           client&.close
         end
 
-        def stop
-          client&.close
-          self.client = nil
-        end
-
         private
 
-        attr_accessor :messaging_client_opts, :client, :sleep_poll, :poll_timeout
-
-        def process_message(client, msg)
-          logger.info("Processing #{msg.message} with msg: #{msg.payload}")
-          # TODO: Move to separate module later when more message types are expected aside from just ordering
-          order_service(msg.payload)
-          client.ack(msg.ack_ref)
-        rescue StandardError => e
-          logger.error(e.message)
-          logger.error(e.backtrace.join("\n"))
-          nil
-        end
-
-        def order_service(payload)
-          task_id, service_plan_id, order_params = payload.values_at("task_id", "service_plan_id", "order_params")
-
-          service_plan     = api_client.show_service_plan(service_plan_id)
-          service_offering = api_client.show_service_offering(service_plan.service_offering_id)
-          source_id        = service_plan.source_id
-
-          catalog_client = Core::ServiceCatalogClient.new(source_id)
-
-          logger.info("Ordering #{service_offering.name} #{service_plan.name}...")
-          service_instance = catalog_client.order_service_plan(
-            service_plan.name, service_offering.name, order_params
-          )
-          logger.info("Ordering #{service_offering.name} #{service_plan.name}...Complete")
-
-          poll_order_complete_thread(task_id, source_id, service_instance)
-        rescue StandardError => err
-          logger.error("Exception while ordering #{err}")
-          logger.error(err.backtrace.join("\n"))
-          update_task(task_id, :state => "completed", :status => "error", :context => {:error => err.to_s})
-        end
-
-        def update_task(task_id, state:, status:, context:)
-          task = TopologicalInventoryApiClient::Task.new("state" => state, "status" => status, "context" => context.to_json)
-          api_client.update_task(task_id, task)
-        end
-
-        def poll_order_complete_thread(task_id, source_id, service_instance)
-          service_instance_name      = service_instance.metadata.name
-          service_instance_namespace = service_instance.metadata.namespace
-
-          Thread.new { poll_order_complete(task_id, source_id, service_instance_name, service_instance_namespace) }
-        end
-
-        def poll_order_complete(task_id, source_id, service_instance_name, service_instance_namespace)
-          logger.info("Waiting for service [#{service_instance_name}] to provision...")
-          catalog_client = Core::ServiceCatalogClient.new(source_id)
-          service_instance = catalog_client.wait_for_provision_complete(
-            service_instance_name, service_instance_namespace
-          )
-          logger.info("Waiting for service [#{service_instance_name}] to provision...Complete")
-
-          context = svc_instance_context_with_url(source_id, service_instance)
-          status  = provisioning_status(service_instance)
-
-          update_task(task_id, :state => "completed", :status => status, :context => context)
-        rescue StandardError => err
-          logger.error("Exception while ordering #{err}")
-          logger.error(err.backtrace.join("\n"))
-          update_task(task_id, :state => "completed", :status => "error", :context => {:error => err.to_s})
-        end
-
-        def svc_instance_context_with_url(source_id, service_instance)
-          context = {
-            :service_instance => {
-              :source_id  => source_id,
-              :source_ref => service_instance.spec&.externalID
-            }
-          }
-
-          if provisioning_status(service_instance) == "ok"
-            url = svc_instance_url(source_id, service_instance)
-            context[:service_instance][:url] = url if url.present?
-          end
-
-          context
-        end
-
-        def svc_instance_url(source_id, service_instance)
-          svc_instance = svc_instance_by_source_ref(source_id, service_instance.spec&.externalID)
-          return if svc_instance.nil?
-
-          rest_api_path = '/service_instances/{id}'.sub('{' + 'id' + '}', svc_instance&.id.to_s)
-          api_client.api_client.build_request(:GET, rest_api_path).url
-        end
-
-        def provisioning_status(service_instance)
-          reason = service_instance.status.conditions.first&.reason
-          reason == "ProvisionedSuccessfully" ? "ok" : "error"
-        end
-
-        # Current API client doesn't support source_id and source_ref filtering
-        # This is modified version of api_client.list_service_instances
-        def svc_instance_by_source_ref(source_id, source_ref)
-          api = api_client.api_client
-
-          header_params = { 'Accept' => api.select_header_accept(['application/json']) }
-          query_params = { :'source_id' => source_id, :'source_ref' => source_ref }
-
-          count = 0
-          timeout_count = poll_timeout / sleep_poll
-
-          service_instance = nil
-          loop do
-            data, status_code, headers = api.call_api(:GET, "/service_instances",
-                                                      :header_params => header_params,
-                                                      :query_params  => query_params,
-                                                      :form_params   => {},
-                                                      :body          => nil,
-                                                      :auth_names    => ['UserSecurity'],
-                                                      :return_type   => 'ServiceInstancesCollection')
-
-            service_instance = data.data&.first if data.meta.count > 0
-            break if service_instance.present?
-
-            break if (count += 1) >= timeout_count
-            sleep(sleep_poll)
-          end
-
-          if service_instance.nil?
-            logger.error("Failed to find service_instance by source_id [#{source_id}] source_ref [#{source_ref}]")
-          end
-
-          service_instance
-        end
-
-        def api_client
-          Thread.current[:topological_inventory_api_client] ||= TopologicalInventoryApiClient::DefaultApi.new
-        end
+        attr_accessor :messaging_client_opts
 
         def queue_opts
           {

--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -1,0 +1,104 @@
+require "topological_inventory/openshift/operations/processor"
+
+RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
+  let(:client) { double(:client) }
+
+  describe "#order_service (private)" do
+    let(:task) { double("Task", :id => 1) }
+
+    let(:service_plan) do
+      TopologicalInventoryApiClient::ServicePlan.new(:id                  => "123",
+                                                     :name                => "plan_name",
+                                                     :source_id           => source.id,
+                                                     :service_offering_id => service_offering.id)
+    end
+    let(:source) do
+      TopologicalInventoryApiClient::Source.new(:id => "321")
+    end
+    let(:service_offering) do
+      TopologicalInventoryApiClient::ServiceOffering.new(:id => "456", :name => "service_offering", :source_id => source.id)
+    end
+
+    let(:service_instance) do
+      TopologicalInventoryApiClient::ServiceInstance.new(:id => "789", :name => "service_instance", :source_ref => "af01c63c-e479-4190-8054-9c5ba2e9ec81")
+    end
+
+    let(:payload) { {"service_plan_id" => service_plan.id.to_s, "order_params" => "order_params", "task_id" => task.id.to_s} }
+
+    let(:service_catalog_client) { instance_double("ServiceCatalogClient") }
+    let(:base_url_path) { "https://virtserver.swaggerhub.com/api/topological-inventory/v0.1/" }
+    let(:service_plan_url) { URI.join(base_url_path, "service_plans/#{service_plan.id}").to_s }
+    let(:source_url) { URI.join(base_url_path, "sources/#{source.id}").to_s }
+    let(:service_offering_url) { URI.join(base_url_path, "service_offerings/#{service_offering.id}").to_s }
+    let(:service_instances_url) { URI.join(base_url_path, "service_instances?source_id=#{source.id}&source_ref=#{service_instance.source_ref}") }
+    let(:task_url) { URI.join(base_url_path, "tasks/#{task.id}").to_s }
+    let(:headers) { {"Content-Type" => "application/json"} }
+    let(:service_instance) do
+      Kubeclient::Resource.new(
+        :metadata => {
+          :name      => "my_service",
+          :namespace => "default",
+          :uid       => "af01c63c-e479-4190-8054-9c5ba2e9ec81"
+        },
+        :status   => {
+          :conditions => [
+            Kubeclient::Resource.new(
+              :reason => "ProvisionedSuccessfully"
+            )
+          ]
+        }
+      )
+    end
+
+    before do
+      require "active_support/json"
+      require "active_support/core_ext/object/json" # required to get service_plan.to_json to work properly
+
+      stub_request(:get, service_plan_url).with(:headers => headers).to_return(
+        :headers => headers, :body => service_plan.to_json
+      )
+      stub_request(:get, source_url).with(:headers => headers).to_return(
+        :headers => headers, :body => source.to_json
+      )
+      stub_request(:get, service_offering_url).with(:headers => headers).to_return(
+        :headers => headers, :body => service_offering.to_json
+      )
+      stub_request(:get, service_instances_url).with(:headers => headers).to_return(
+        :headers => headers, :body => {:meta => {:count => 1}, :data => [service_instance.to_hash]}.to_json
+      )
+
+      allow(
+        TopologicalInventory::Openshift::Operations::Core::ServiceCatalogClient
+      ).to receive(:new).with(source.id).and_return(service_catalog_client)
+
+      allow(service_catalog_client).to receive(:order_service_plan).and_return(service_instance)
+      allow(service_catalog_client).to receive(:wait_for_provision_complete).and_return(service_instance)
+
+      stub_request(:patch, task_url).with(:headers => headers)
+    end
+
+    it "orders the service via the service catalog client" do
+      expect(service_catalog_client).to receive(:order_service_plan).with("plan_name", "service_offering", "order_params")
+      expect(service_catalog_client).to receive(:wait_for_provision_complete).with(service_instance.metadata.name, service_instance.metadata.namespace)
+      thread = described_class.new("ServicePlan", "order", payload).send(:order_service, payload)
+      thread.join
+    end
+
+    it "makes a patch request to the update task endpoint with the status and context" do
+      expected_context = {
+        :service_instance => {
+          :source_id  => source.id,
+          :source_ref => service_instance.source_ref,
+          :url        => "#{base_url_path}service_instances/#{service_instance.id}"
+        }
+      }.to_json
+
+      thread = described_class.new("ServicePlan", "order", payload).send(:order_service, payload)
+      thread.join
+
+      expect(
+        a_request(:patch, task_url).with(:body => {"status" => "ok", "state" => "completed", "context" => expected_context})
+      ).to have_been_made
+    end
+  end
+end

--- a/spec/topological_inventory/openshift/operations/worker_spec.rb
+++ b/spec/topological_inventory/openshift/operations/worker_spec.rb
@@ -1,104 +1,19 @@
 require "topological_inventory/openshift/operations/worker"
 
 RSpec.describe TopologicalInventory::Openshift::Operations::Worker do
-  let(:client) { double(:client) }
-
-  describe "#order_service (private)" do
-    let(:task) { double("Task", :id => 1) }
-
-    let(:service_plan) do
-      TopologicalInventoryApiClient::ServicePlan.new(:id                  => "123",
-                                                     :name                => "plan_name",
-                                                     :source_id           => source.id,
-                                                     :service_offering_id => service_offering.id)
-    end
-    let(:source) do
-      TopologicalInventoryApiClient::Source.new(:id => "321")
-    end
-    let(:service_offering) do
-      TopologicalInventoryApiClient::ServiceOffering.new(:id => "456", :name => "service_offering", :source_id => source.id)
-    end
-
-    let(:service_instance) do
-      TopologicalInventoryApiClient::ServiceInstance.new(:id => "789", :name => "service_instance", :source_ref => "af01c63c-e479-4190-8054-9c5ba2e9ec81")
-    end
-
-    let(:payload) { {"service_plan_id" => service_plan.id.to_s, "order_params" => "order_params", "task_id" => task.id.to_s} }
-
-    let(:service_catalog_client) { instance_double("ServiceCatalogClient") }
-    let(:base_url_path) { "https://virtserver.swaggerhub.com/api/topological-inventory/v0.1/" }
-    let(:service_plan_url) { URI.join(base_url_path, "service_plans/#{service_plan.id}").to_s }
-    let(:source_url) { URI.join(base_url_path, "sources/#{source.id}").to_s }
-    let(:service_offering_url) { URI.join(base_url_path, "service_offerings/#{service_offering.id}").to_s }
-    let(:service_instances_url) { URI.join(base_url_path, "service_instances?source_id=#{source.id}&source_ref=#{service_instance.source_ref}") }
-    let(:task_url) { URI.join(base_url_path, "tasks/#{task.id}").to_s }
-    let(:headers) { {"Content-Type" => "application/json"} }
-    let(:service_instance) do
-      Kubeclient::Resource.new(
-        :metadata => {
-          :name      => "my_service",
-          :namespace => "default",
-          :uid       => "af01c63c-e479-4190-8054-9c5ba2e9ec81"
-        },
-        :status   => {
-          :conditions => [
-            Kubeclient::Resource.new(
-              :reason => "ProvisionedSuccessfully"
-            )
-          ]
-        }
-      )
-    end
-
+  describe "#run" do
+    let(:client) { double("ManageIQ::Messaging::Client") }
+    let(:subject) { described_class.new }
     before do
-      require "active_support/json"
-      require "active_support/core_ext/object/json" # required to get service_plan.to_json to work properly
-
-      stub_request(:get, service_plan_url).with(:headers => headers).to_return(
-        :headers => headers, :body => service_plan.to_json
-      )
-      stub_request(:get, source_url).with(:headers => headers).to_return(
-        :headers => headers, :body => source.to_json
-      )
-      stub_request(:get, service_offering_url).with(:headers => headers).to_return(
-        :headers => headers, :body => service_offering.to_json
-      )
-      stub_request(:get, service_instances_url).with(:headers => headers).to_return(
-        :headers => headers, :body => {:meta => {:count => 1}, :data => [service_instance.to_hash]}.to_json
-      )
-
-      allow(
-        TopologicalInventory::Openshift::Operations::Core::ServiceCatalogClient
-      ).to receive(:new).with(source.id).and_return(service_catalog_client)
-
-      allow(service_catalog_client).to receive(:order_service_plan).and_return(service_instance)
-      allow(service_catalog_client).to receive(:wait_for_provision_complete).and_return(service_instance)
-
-      stub_request(:patch, task_url).with(:headers => headers)
+      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      allow(client).to receive(:close)
     end
 
-    it "orders the service via the service catalog client" do
-      expect(service_catalog_client).to receive(:order_service_plan).with("plan_name", "service_offering", "order_params")
-      expect(service_catalog_client).to receive(:wait_for_provision_complete).with(service_instance.metadata.name, service_instance.metadata.namespace)
-      thread = described_class.new.send(:order_service, payload)
-      thread.join
-    end
-
-    it "makes a patch request to the update task endpoint with the status and context" do
-      expected_context = {
-        :service_instance => {
-          :source_id  => source.id,
-          :source_ref => service_instance.source_ref,
-          :url        => "#{base_url_path}service_instances/#{service_instance.id}"
-        }
-      }.to_json
-
-      thread = described_class.new.send(:order_service, payload)
-      thread.join
-
-      expect(
-        a_request(:patch, task_url).with(:body => {"status" => "ok", "state" => "completed", "context" => expected_context})
-      ).to have_been_made
+    it "calls subscribe_messages on the right queue" do
+      operations_topic = "platform.topological-inventory.operations-openshift"
+      expect(client).to receive(:subscribe_messages)
+        .with(hash_including(:service => operations_topic))
+      subject.run
     end
   end
 end


### PR DESCRIPTION
This lets us set context at the class level per operation (like identity
headers).