### PR TITLE
Generate scope based on built entities

### DIFF
--- a/lib/topological_inventory/openshift/collector.rb
+++ b/lib/topological_inventory/openshift/collector.rb
@@ -161,6 +161,10 @@ module TopologicalInventory::Openshift
     end
 
     def targeted_sweep_scopes
+      # Set attribute names that are determining the scope of the subcollections
+      # e.g. for containers it's container_group attribute, which is a lazy find to container group. So we collect all
+      # container_groups of the saved containers and we take them as a scope. That means containers of those
+      # container groups that no longer exist, will be sweeped.
       @targeted_sweep_scopes ||= {
         :container_image_tags    => [:container_image],
         :containers              => [:container_group],
@@ -170,8 +174,6 @@ module TopologicalInventory::Openshift
         :container_template_tags => [:container_template],
         :service_offering_tags   => [:container_offering],
         :service_offering_icons  => [:container_offering],
-        :vm_tags                 => [:vm],
-        :volume_attachments      => [:volume],
       }
     end
 


### PR DESCRIPTION
All entities needs to be sweepend now.

For full refresh, we simply generate the sweep scope as array of entities, from all the batches of the payload. So e.g. if in our batches we've build :containers and :container_groups, the scope will be 
```[:containers, :container_groups]```

For targeted refresh we don't need to do sweep for parent objects, because we catch also delete events. So the e.g. the container_groups will be archived by update.

For nested objects, we generate the scope from the object itself, based on manually defined mapping. So e.g. for containers, we define the mapping as ``` :containers              => [:container_group],```

So we'll extract the :container_group lazy link from each container and send it as a scope. So e.g.
```scope = {:containers => [{:container_group => lazy_container_group1}]}```

That will sweep all containers under `lazy_container_group1`, that didn't have `last_seen_on` updated