### PR TITLE
Fix a missing require for operations processor

### DIFF
--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -1,5 +1,6 @@
 require "manageiq-messaging"
 require "topological_inventory/openshift/logging"
+require "topological_inventory/openshift/operations/processor"
 require "topological_inventory/openshift/operations/core/service_catalog_client"
 require "topological_inventory-api-client"
 


### PR DESCRIPTION
The operations processor wasn't being required causing the message
processing to fail.