### PR TITLE
Pass identity headers in service catalog client

### DIFF
--- a/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
+++ b/lib/topological_inventory/openshift/operations/core/authentication_retriever.rb
@@ -3,14 +3,17 @@ module TopologicalInventory
     module Operations
       module Core
         class AuthenticationRetriever
-          def initialize(id)
-            @id = id.to_s
+          def initialize(id, identity = nil)
+            @id       = id.to_s
+            @identity = identity
           end
 
           def process
             headers = {
               "Content-Type" => "application/json"
             }
+
+            headers.merge!(@identity) if @identity.present?
 
             scheme     = TopologicalInventoryApiClient.configure.scheme
             host, port = TopologicalInventoryApiClient.configure.host.split(":")

--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -30,7 +30,7 @@ module TopologicalInventory
           service_offering = api_client.show_service_offering(service_plan.service_offering_id)
           source_id        = service_plan.source_id
 
-          catalog_client = Core::ServiceCatalogClient.new(source_id)
+          catalog_client = Core::ServiceCatalogClient.new(source_id, payload["identity"])
 
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...")
           service_instance = catalog_client.order_service_plan(

--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -59,7 +59,7 @@ module TopologicalInventory
 
         def poll_order_complete(task_id, source_id, service_instance_name, service_instance_namespace)
           logger.info("Waiting for service [#{service_instance_name}] to provision...")
-          catalog_client = Core::ServiceCatalogClient.new(source_id)
+          catalog_client = Core::ServiceCatalogClient.new(source_id, payload["identity"])
           service_instance = catalog_client.wait_for_provision_complete(
             service_instance_name, service_instance_namespace
           )

--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -23,12 +23,14 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
       TopologicalInventoryApiClient::ServiceInstance.new(:id => "789", :name => "service_instance", :source_ref => "af01c63c-e479-4190-8054-9c5ba2e9ec81")
     end
 
+    let(:identity) { {"x-rh-identity"=>"eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjI0MCJ9fQ==\n"} }
+
     let(:payload) do
       {
         "service_plan_id" => service_plan.id.to_s,
         "order_params"    => "order_params",
         "task_id"         => task.id.to_s,
-        "identity"        => {"x-rh-identity"=>"eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjI0MCJ9fQ==\n"},
+        "identity"        => identity,
       }
     end
 
@@ -76,7 +78,7 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
 
       allow(
         TopologicalInventory::Openshift::Operations::Core::ServiceCatalogClient
-      ).to receive(:new).with(source.id).and_return(service_catalog_client)
+      ).to receive(:new).with(source.id, identity).and_return(service_catalog_client)
 
       allow(service_catalog_client).to receive(:order_service_plan).and_return(service_instance)
       allow(service_catalog_client).to receive(:wait_for_provision_complete).and_return(service_instance)


### PR DESCRIPTION
We weren't passing the identity headers in the ServiceCatalogClient API requests causing errors like:

```
{"@timestamp":"2019-04-03T14:39:01.412137 ","hostname":"topological-inventory-openshift-operations-36-9ctbh","pid":1,"tid":"caaf58","level":"err","message":"Exception while ordering Unauthorized"}
{"@timestamp":"2019-04-03T14:39:01.412222 ","hostname":"topological-inventory-openshift-operations-36-9ctbh","pid":1,"tid":"caaf58","level":"err","message":"/usr/local/lib/ruby/gems/2.4.0/bundler/gems/topological_inventory-api-client-ruby-1257255538e7/lib/topological_inventory-api-client/api_client.rb:65:in `call_api'
```