### PR TITLE
Update the payload format splitting out identity

### DIFF
--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -8,29 +8,32 @@ module TopologicalInventory
         include Logging
 
         def initialize(model, method, payload)
-          self.model   = model
-          self.method  = method
-          self.payload = payload
+          self.model           = model
+          self.method          = method
+          self.params          = payload["params"]
+          self.request_context = payload["request_context"]
         end
 
         def process
-          logger.info("Processing #{model}##{method} [#{payload}]...")
-          order_service(payload)
-          logger.info("Processing #{model}##{method} [#{payload}]...Complete")
+          logger.info("Processing #{model}##{method} [#{params}]...")
+          result = order_service(params)
+          logger.info("Processing #{model}##{method} [#{params}]...Complete")
+
+          result
         end
 
         private
 
-        attr_accessor :model, :method, :payload
+        attr_accessor :model, :method, :params, :request_context
 
-        def order_service(payload)
-          task_id, service_plan_id, order_params = payload.values_at("task_id", "service_plan_id", "order_params")
+        def order_service(params)
+          task_id, service_plan_id, order_params = params.values_at("task_id", "service_plan_id", "order_params")
 
           service_plan     = api_client.show_service_plan(service_plan_id)
           service_offering = api_client.show_service_offering(service_plan.service_offering_id)
           source_id        = service_plan.source_id
 
-          catalog_client = Core::ServiceCatalogClient.new(source_id, payload["identity"])
+          catalog_client = Core::ServiceCatalogClient.new(source_id, request_context)
 
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...")
           service_instance = catalog_client.order_service_plan(
@@ -59,7 +62,7 @@ module TopologicalInventory
 
         def poll_order_complete(task_id, source_id, service_instance_name, service_instance_namespace)
           logger.info("Waiting for service [#{service_instance_name}] to provision...")
-          catalog_client = Core::ServiceCatalogClient.new(source_id, payload["identity"])
+          catalog_client = Core::ServiceCatalogClient.new(source_id, request_context)
           service_instance = catalog_client.wait_for_provision_complete(
             service_instance_name, service_instance_namespace
           )
@@ -146,7 +149,7 @@ module TopologicalInventory
           @api_client ||=
             begin
               api_client = TopologicalInventoryApiClient::ApiClient.new
-              api_client.default_headers.merge!(payload["identity"]) if payload["identity"].present?
+              api_client.default_headers.merge!(request_context) if request_context.present?
               TopologicalInventoryApiClient::DefaultApi.new(api_client)
             end
         end

--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
 
     let(:payload) do
       {
-        "service_plan_id" => service_plan.id.to_s,
-        "order_params"    => "order_params",
-        "task_id"         => task.id.to_s,
-        "identity"        => identity,
+        "request_context" => identity,
+        "params"          => {
+          "service_plan_id" => service_plan.id.to_s,
+          "order_params"    => "order_params",
+          "task_id"         => task.id.to_s,
+        }
       }
     end
 
@@ -89,7 +91,7 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
     it "orders the service via the service catalog client" do
       expect(service_catalog_client).to receive(:order_service_plan).with("plan_name", "service_offering", "order_params")
       expect(service_catalog_client).to receive(:wait_for_provision_complete).with(service_instance.metadata.name, service_instance.metadata.namespace)
-      thread = described_class.new("ServicePlan", "order", payload).send(:order_service, payload)
+      thread = described_class.new("ServicePlan", "order", payload).process
       thread.join
     end
 
@@ -102,7 +104,7 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
         }
       }.to_json
 
-      thread = described_class.new("ServicePlan", "order", payload).send(:order_service, payload)
+      thread = described_class.new("ServicePlan", "order", payload).process
       thread.join
 
       expect(


### PR DESCRIPTION
Split out the request context for the user identity out from the rest of
the method parameters.

Should be merged together with https://github.com/ManageIQ/topological_inventory-api/pull/177