### PR TITLE
Add service_instance.id to task context when updating

### DIFF
--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -86,6 +86,7 @@ module TopologicalInventory
           if provisioning_status(service_instance) == "ok"
             url = svc_instance_url(source_id, service_instance)
             context[:service_instance][:url] = url if url.present?
+            context[:service_instance][:id] = service_instance.id
           end
 
           context

--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
         :service_instance => {
           :source_id  => source.id,
           :source_ref => service_instance.source_ref,
-          :url        => "#{base_url_path}service_instances/#{service_instance.id}"
+          :url        => "#{base_url_path}service_instances/#{service_instance.id}",
+          :id         => service_instance.id
         }
       }.to_json
 


### PR DESCRIPTION
This is intended to be used instead of the full URL that comes back so that anything that is using the topology api client (for my purposes, catalog) can simply call `show_service_instance(id)` instead of having to piece apart the URL and manually build a request.

@agrare Please review