### PR TITLE
Replace :id in completed task context with correct svc_instance id

### DIFF
--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -87,18 +87,16 @@ module TopologicalInventory
           }
 
           if provisioning_status(service_instance) == "ok"
-            url = svc_instance_url(source_id, service_instance)
-            context[:service_instance][:url] = url if url.present?
-            context[:service_instance][:id] = service_instance.id
+            svc_instance = svc_instance_by_source_ref(source_id, service_instance.spec&.externalID)
+            return context if svc_instance.nil?
+            context[:service_instance][:id] = svc_instance.id
+            context[:service_instance][:url] = svc_instance_url(svc_instance)
           end
 
           context
         end
 
-        def svc_instance_url(source_id, service_instance)
-          svc_instance = svc_instance_by_source_ref(source_id, service_instance.spec&.externalID)
-          return if svc_instance.nil?
-
+        def svc_instance_url(svc_instance)
           rest_api_path = '/service_instances/{id}'.sub('{' + 'id' + '}', svc_instance&.id.to_s)
           api_client.api_client.build_request(:GET, rest_api_path).url
         end

--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
               :reason => "ProvisionedSuccessfully"
             )
           ]
-        }
+        },
+        :id       => 123
       )
     end
 
@@ -100,8 +101,8 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
         :service_instance => {
           :source_id  => source.id,
           :source_ref => service_instance.source_ref,
-          :url        => "#{base_url_path}service_instances/#{service_instance.id}",
-          :id         => service_instance.id
+          :id         => service_instance.id.to_s,
+          :url        => "#{base_url_path}service_instances/#{service_instance.id}"
         }
       }.to_json
 


### PR DESCRIPTION
I inadvertently used the incorrect `service_instance.id` when adding the `:id` to the context of the completed task object, so it was just always returning `null`. This should fix that.

@agrare Please Review