### PR TITLE
Fix processor_spec pointing to virtserver.swaggerhub.com

### DIFF
--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
     end
 
     let(:service_catalog_client) { instance_double("ServiceCatalogClient") }
-    let(:base_url_path) { "https://virtserver.swaggerhub.com/api/topological-inventory/v0.1/" }
+    let(:base_url_path) { "https://cloud.redhat.com/api/topological-inventory/v1.0/" }
     let(:service_plan_url) { URI.join(base_url_path, "service_plans/#{service_plan.id}").to_s }
     let(:source_url) { URI.join(base_url_path, "sources/#{source.id}").to_s }
     let(:service_offering_url) { URI.join(base_url_path, "service_offerings/#{service_offering.id}").to_s }


### PR DESCRIPTION
Now that the topological_inventory-api-client is on version 1.0 and the
base url is pointing to cloud.redhat.com we need to update the spec
mocks