### PR TITLE
Collector's common methods moved to Ingress API client

### DIFF
--- a/lib/topological_inventory/openshift/collector.rb
+++ b/lib/topological_inventory/openshift/collector.rb
@@ -8,21 +8,19 @@ require "topological_inventory-ingress_api-client"
 require "topological_inventory-ingress_api-client/save_inventory/saver"
 
 module TopologicalInventory::Openshift
-  class Collector
+  class Collector < TopologicalInventoryIngressApiClient::Collector
     include Logging
 
     def initialize(source, openshift_host, openshift_port, openshift_token, metrics, default_limit: 500, poll_time: 30)
+      super(source,
+            :default_limit => default_limit,
+            :poll_time     => poll_time)
+
       self.connection_manager = Connection.new
-      self.collector_threads = Concurrent::Map.new
-      self.finished          = Concurrent::AtomicBoolean.new(false)
-      self.limits            = Hash.new(default_limit)
       self.metrics           = metrics
       self.openshift_host    = openshift_host
       self.openshift_port    = openshift_port
       self.openshift_token   = openshift_token
-      self.poll_time         = poll_time
-      self.queue             = Queue.new
-      self.source            = source
     end
 
     def collect!
@@ -50,37 +48,16 @@ module TopologicalInventory::Openshift
       end
     end
 
-    def stop
-      finished.value = true
-    end
-
     private
 
-    attr_accessor :connection_manager, :collector_threads, :finished, :limits,
-                  :metrics, :openshift_host, :openshift_token, :openshift_port,
-                  :poll_time, :queue, :source
+    attr_accessor :connection_manager,
+                  :metrics, :openshift_host, :openshift_token, :openshift_port
 
-    def finished?
-      finished.value
-    end
-
-    def ensure_collector_threads
-      entity_types.each do |entity_type|
-        next if collector_threads[entity_type]&.alive?
-
-        collector_threads[entity_type] = start_collector_thread(entity_type)
-      end
-    end
-    alias start_collector_threads ensure_collector_threads
 
     def start_collector_thread(entity_type)
       logger.info("Starting collector thread for #{entity_type}...")
-      connection = connection_for_entity_type(entity_type)
-      return if connection.nil?
 
-      Thread.new do
-        collector_thread(connection, entity_type)
-      end
+      super
     rescue Kubeclient::ResourceNotFoundError => err
       logger.warn("Entity type '#{entity_type}' not found: #{err}")
       nil
@@ -189,51 +166,6 @@ module TopologicalInventory::Openshift
       }
     end
 
-    def save_inventory(collections, refresh_state_uuid = nil, refresh_state_part_uuid = nil)
-      return 0 if collections.empty?
-
-      TopologicalInventoryIngressApiClient::SaveInventory::Saver.new(:client => ingress_api_client, :logger => logger).save(
-        :inventory => TopologicalInventoryIngressApiClient::Inventory.new(
-          :name                    => "OCP",
-          :schema                  => TopologicalInventoryIngressApiClient::Schema.new(:name => "Default"),
-          :source                  => source,
-          :collections             => collections,
-          :refresh_state_uuid      => refresh_state_uuid,
-          :refresh_state_part_uuid => refresh_state_part_uuid,
-        )
-      )
-    rescue => e
-      response_body = e.response_body if e.respond_to? :response_body
-      response_headers = e.response_headers if e.respond_to? :response_headers
-      logger.error("Error when sending payload to Ingress API. Error message: #{e.message}. Body: #{response_body}. Header: #{response_headers}")
-      raise e
-    end
-
-    def sweep_inventory(refresh_state_uuid, total_parts, sweep_scope)
-      return if !total_parts || sweep_scope.empty?
-
-      TopologicalInventoryIngressApiClient::SaveInventory::Saver.new(:client => ingress_api_client, :logger => logger).save(
-        :inventory => TopologicalInventoryIngressApiClient::Inventory.new(
-          :name               => "OCP",
-          :schema             => TopologicalInventoryIngressApiClient::Schema.new(:name => "Default"),
-          :source             => source,
-          :collections        => [],
-          :refresh_state_uuid => refresh_state_uuid,
-          :total_parts        => total_parts,
-          :sweep_scope        => sweep_scope,
-        )
-      )
-    rescue => e
-      response_body = e.response_body if e.respond_to? :response_body
-      response_headers = e.response_headers if e.respond_to? :response_headers
-      logger.error("Error when sending payload to Ingress API. Error message: #{e.message}. Body: #{response_body}. Header: #{response_headers}")
-      raise e
-    end
-
-    def entity_types
-      endpoint_types.flat_map { |endpoint| send("#{endpoint}_entity_types") }
-    end
-
     def kubernetes_entity_types
       %w[namespaces pods nodes resource_quotas]
     end
@@ -267,6 +199,11 @@ module TopologicalInventory::Openshift
 
     def connection_params
       {:host => openshift_host, :port => openshift_port, :token => openshift_token}
+    end
+
+    # Used for Save & Sweep Inventory
+    def inventory_name
+      "OCP"
     end
 
     def ingress_api_client

--- a/lib/topological_inventory/openshift/collector.rb
+++ b/lib/topological_inventory/openshift/collector.rb
@@ -102,7 +102,7 @@ module TopologicalInventory::Openshift
         parser.send("parse_#{entity_type}", entities)
 
         refresh_state_part_uuid = SecureRandom.uuid
-        total_parts += save_inventory(parser.collections.values, refresh_state_uuid, refresh_state_part_uuid)
+        total_parts += save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid)
         sweep_scope.merge(parser.collections.values.map(&:name))
 
         break if entities.last?
@@ -113,7 +113,7 @@ module TopologicalInventory::Openshift
       sweep_scope = sweep_scope.to_a
       logger.info("Sweeping inactive records for #{sweep_scope} with :refresh_state_uuid => '#{refresh_state_uuid}'...")
 
-      sweep_inventory(refresh_state_uuid, total_parts, sweep_scope)
+      sweep_inventory(inventory_name, schema_name, refresh_state_uuid, total_parts, sweep_scope)
 
       logger.info("Sweeping inactive records for #{sweep_scope} with :refresh_state_uuid => '#{refresh_state_uuid}'...Complete")
       resource_version
@@ -132,9 +132,9 @@ module TopologicalInventory::Openshift
 
       refresh_state_uuid      = SecureRandom.uuid
       refresh_state_part_uuid = SecureRandom.uuid
-      total_parts = save_inventory(parser.collections.values, refresh_state_uuid, refresh_state_part_uuid)
+      total_parts = save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid)
 
-      sweep_inventory(refresh_state_uuid, total_parts, parse_targeted_sweep_scope(parser.collections.values))
+      sweep_inventory(inventory_name, schema_name, refresh_state_uuid, total_parts, parse_targeted_sweep_scope(parser.collections.values))
     end
 
     def parse_targeted_sweep_scope(collections)

--- a/lib/topological_inventory/openshift/collector.rb
+++ b/lib/topological_inventory/openshift/collector.rb
@@ -5,7 +5,6 @@ require "topological_inventory/openshift/logging"
 require "topological_inventory/openshift/connection"
 require "topological_inventory/openshift/parser"
 require "topological_inventory-ingress_api-client"
-require "topological_inventory-ingress_api-client/save_inventory/saver"
 
 module TopologicalInventory::Openshift
   class Collector < TopologicalInventoryIngressApiClient::Collector

--- a/spec/topological_inventory/openshift/collector_spec.rb
+++ b/spec/topological_inventory/openshift/collector_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
 
   context "#save_inventory" do
     it "does nothing with empty collections" do
-      parts = collector.send(:save_inventory, [], refresh_state_uuid, refresh_state_part_uuid)
+      parts = collector.send(:save_inventory, [], collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid)
 
       expect(parts).to eq 0
     end
@@ -38,7 +38,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       expect(inventory_size(parser.collections.values)).to eq(999242)
 
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
-      parts = collector.send(:save_inventory, parser.collections.values, refresh_state_uuid, refresh_state_part_uuid)
+      parts = collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid)
       expect(parts).to eq 1
     end
 
@@ -48,7 +48,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       expect(inventory_size(parser.collections.values)).to eq(1998242)
 
       expect(client).to receive(:save_inventory_with_http_info).exactly(2).times
-      parts = collector.send(:save_inventory, parser.collections.values, refresh_state_uuid, refresh_state_part_uuid)
+      parts = collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid)
       expect(parts).to eq 2
     end
 
@@ -59,7 +59,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       expect(inventory_size(parser.collections.values)).to eq(1998278)
 
       expect(client).to receive(:save_inventory_with_http_info).exactly(2).times
-      parts = collector.send(:save_inventory, parser.collections.values, refresh_state_uuid, refresh_state_part_uuid)
+      parts = collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid)
       expect(parts).to eq 2
     end
 
@@ -68,7 +68,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       (multiplier * 2000).times { parser.collections.container_nodes.build(:source_ref => "a" * 981) }
 
       expect(client).to receive(:save_inventory_with_http_info).exactly(4).times
-      parts = collector.send(:save_inventory, parser.collections.values, refresh_state_uuid, refresh_state_part_uuid)
+      parts = collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid)
       expect(parts).to eq 4
     end
 
@@ -79,7 +79,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       # in this case, we first save empty inventory, then the size check fails saving the rest of data
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
 
-      expect { collector.send(:save_inventory, parser.collections.values, refresh_state_uuid, refresh_state_part_uuid) }.to(
+      expect { collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid) }.to(
         raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
       )
     end
@@ -92,7 +92,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       # We save the first collection then it fails on saving the second collection
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
 
-      expect { collector.send(:save_inventory, parser.collections.values, refresh_state_uuid, refresh_state_part_uuid) }.to(
+      expect { collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid) }.to(
         raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
       )
     end
@@ -106,7 +106,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       # We save the first collection then it fails on saving the second collection
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
 
-      expect { collector.send(:save_inventory, parser.collections.values, refresh_state_uuid, refresh_state_part_uuid) }.to(
+      expect { collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid) }.to(
         raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
       )
     end
@@ -116,25 +116,25 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
     it "with nil total parts" do
       expect(client).to receive(:save_inventory_with_http_info).exactly(0).times
 
-      collector.send(:sweep_inventory, refresh_state_uuid, nil, [])
+      collector.send(:sweep_inventory, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, nil, [])
     end
 
     it "with empty scope " do
       expect(client).to receive(:save_inventory_with_http_info).exactly(0).times
 
-      collector.send(:sweep_inventory, refresh_state_uuid, 1, [])
+      collector.send(:sweep_inventory, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, 1, [])
     end
 
     it "with normal scope " do
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
 
-      collector.send(:sweep_inventory, refresh_state_uuid, 1, [:container_groups])
+      collector.send(:sweep_inventory, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, 1, [:container_groups])
     end
 
     it "with normal targeted scope " do
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
 
-      collector.send(:sweep_inventory, refresh_state_uuid, 1, {:container_groups => [{:source_ref => "a"}]})
+      collector.send(:sweep_inventory, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, 1, {:container_groups => [{:source_ref => "a"}]})
     end
 
     it "fails with scope entity too large " do
@@ -142,7 +142,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
 
       sweep_scope = {:container_groups => [{:source_ref => "a" * 1_000_002 * multiplier}]}
 
-      expect { collector.send(:sweep_inventory, refresh_state_uuid, 1, sweep_scope) }.to(
+      expect { collector.send(:sweep_inventory, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, 1, sweep_scope) }.to(
         raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
       )
     end
@@ -153,7 +153,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
 
       sweep_scope = {:container_groups => (0..1001 * multiplier).map { {:source_ref => "a" * 1_000} } }
 
-      expect { collector.send(:sweep_inventory, refresh_state_uuid, 1, sweep_scope) }.to(
+      expect { collector.send(:sweep_inventory, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, 1, sweep_scope) }.to(
         raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
       )
     end
@@ -161,8 +161,8 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
 
   def build_inventory(collections)
     TopologicalInventoryIngressApiClient::Inventory.new(
-      :name                    => "OCP",
-      :schema                  => TopologicalInventoryIngressApiClient::Schema.new(:name => "Default"),
+      :name                    => collector.send(:inventory_name),
+      :schema                  => TopologicalInventoryIngressApiClient::Schema.new(:name => collector.send(:schema_name)),
       :source                  => source,
       :collections             => collections,
       :refresh_state_uuid      => refresh_state_uuid,


### PR DESCRIPTION
Collector classes have many common methods used across all collectors(sources). Extracted to Ingress API client

- [x] **depends on**: https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/36
- [x]  **depends on** https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/37
- [x] **depends on** https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/38