### PR TITLE
Metrics port as an argument

### DIFF
--- a/bin/openshift-collector
+++ b/bin/openshift-collector
@@ -23,6 +23,7 @@ def parse_args
         :type => :string, :required => ENV["AUTH_PASSWORD"].nil?, :default => ENV["AUTH_PASSWORD"]
     opt :ingress_api, "Hostname of the ingress-api route",
         :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
   end
 
   opts

--- a/lib/topological_inventory/openshift/collector/application_metrics.rb
+++ b/lib/topological_inventory/openshift/collector/application_metrics.rb
@@ -7,16 +7,18 @@ module TopologicalInventory::Openshift
   class Collector
     class ApplicationMetrics
       def initialize(port = 9394)
+        return if port == 0
+
         configure_server(port)
         configure_metrics
       end
 
       def record_error
-        @errors_counter.observe(1)
+        @errors_counter&.observe(1)
       end
 
       def stop_server
-        @server.stop
+        @server&.stop
       end
 
       private

--- a/spec/topological_inventory/openshift/collector/application_metrics_spec.rb
+++ b/spec/topological_inventory/openshift/collector/application_metrics_spec.rb
@@ -8,25 +8,36 @@ RSpec.describe TopologicalInventory::Openshift::Collector::ApplicationMetrics do
     WebMock.enable!
   end
 
-  subject! { described_class.new(9394) }
-  after    { subject.stop_server }
+  context "Turned on" do
+    subject! { described_class.new(9394) }
+    after    { subject.stop_server }
 
-  it "exposes metrics" do
-    subject.record_error
-    subject.record_error
+    it "exposes metrics" do
+      subject.record_error
+      subject.record_error
 
-    metrics = get_metrics
-    expect(metrics["topological_inventory_openshift_collector_errors_total"]).to eq("2")
-  end
-
-  def get_metrics
-    metrics = Net::HTTP.get(URI("http://localhost:9394/metrics")).split("\n").delete_if do |e|
-      e.blank? || e.start_with?("#")
+      metrics = get_metrics
+      expect(metrics["topological_inventory_openshift_collector_errors_total"]).to eq("2")
     end
 
-    metrics.each_with_object({}) do |m, hash|
-      k, v = m.split
-      hash[k] = v
+    def get_metrics
+      metrics = Net::HTTP.get(URI("http://localhost:9394/metrics")).split("\n").delete_if do |e|
+        e.blank? || e.start_with?("#")
+      end
+
+      metrics.each_with_object({}) do |m, hash|
+        k, v = m.split
+        hash[k] = v
+      end
+    end
+  end
+
+  context "Turned off" do
+    subject! { described_class.new(0) }
+
+    it "doesn't raise exception" do
+      expect { subject.record_error }.not_to raise_exception
+      expect { subject.stop_server }.not_to raise_exception
     end
   end
 end


### PR DESCRIPTION
Metrics port is configurable by `metrics_port` arg and `ENV["METRICS_PORT"]. Defaults to 9394

Port 0 disables metrics