### PR TITLE
Source.availability_check

### DIFF
--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -22,7 +22,7 @@ module TopologicalInventory
           logger.info("Processing #{model}##{method} [#{params}]...")
 
           if Operations.const_defined?(model)
-            impl = Operations.const_get(model).new(params)
+            impl = Operations.const_get(model).new(params, identity)
             unless impl.respond_to?(method)
               logger.error("#{model}.#{method} is not implemented")
               return

--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -21,14 +21,17 @@ module TopologicalInventory
         def process
           logger.info("Processing #{model}##{method} [#{params}]...")
 
-          result = if Operations.const_defined?(model)
-                     impl = Operations.const_get(model).new(params)
-                     raise "#{model}.#{method} is not implemented" unless impl.respond_to?(method)
+          if Operations.const_defined?(model)
+            impl = Operations.const_get(model).new(params)
+            unless impl.respond_to?(method)
+              logger.error("#{model}.#{method} is not implemented")
+              return
+            end
 
-                     impl.send(method)
-                   else
-                     order_service(params)
-                   end
+            result = impl.send(method)
+          else
+            result = order_service(params)
+          end
 
           logger.info("Processing #{model}##{method} [#{params}]...Complete")
 

--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -1,6 +1,7 @@
 require "topological_inventory/openshift/logging"
 require "topological_inventory/openshift/operations/core/service_catalog_client"
 require "topological_inventory/openshift/operations/core/topology_api_client"
+require "topological_inventory/openshift/operations/source"
 
 module TopologicalInventory
   module Openshift
@@ -19,7 +20,16 @@ module TopologicalInventory
 
         def process
           logger.info("Processing #{model}##{method} [#{params}]...")
-          result = order_service(params)
+
+          result = if Operations.const_defined?(model)
+                     impl = Operations.const_get(model)
+                     raise "#{model}.#{method} is not implemented" unless impl.respond_to?(method)
+
+                     impl.send(method, params)
+                   else
+                     order_service(params)
+                   end
+
           logger.info("Processing #{model}##{method} [#{params}]...Complete")
 
           result

--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -22,10 +22,10 @@ module TopologicalInventory
           logger.info("Processing #{model}##{method} [#{params}]...")
 
           result = if Operations.const_defined?(model)
-                     impl = Operations.const_get(model)
+                     impl = Operations.const_get(model).new(params)
                      raise "#{model}.#{method} is not implemented" unless impl.respond_to?(method)
 
-                     impl.send(method, params)
+                     impl.send(method)
                    else
                      order_service(params)
                    end

--- a/lib/topological_inventory/openshift/operations/source.rb
+++ b/lib/topological_inventory/openshift/operations/source.rb
@@ -1,0 +1,11 @@
+module TopologicalInventory
+  module Openshift
+    module Operations
+      module Source
+        def self.availability_check(params)
+          puts "Running: availability_check for Source id: #{params["source_id"]}"
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/openshift/operations/source.rb
+++ b/lib/topological_inventory/openshift/operations/source.rb
@@ -26,10 +26,8 @@ module TopologicalInventory
             return if params["timestamp"] < (Time.now.utc - 1.minute)
           end
 
-          api_client = SourcesApiClient::DefaultApi.new
-
           source = SourcesApiClient::Source.new
-          source.availability_status = connection_check(api_client, source_id)
+          source.availability_status = connection_check(source_id)
 
           begin
             api_client.update_source(source_id, source)
@@ -40,7 +38,7 @@ module TopologicalInventory
 
         private
 
-        def connection_check(api_client, source_id)
+        def connection_check(source_id)
           endpoints = api_client.list_source_endpoints(source_id)&.data || []
           endpoint = endpoints.find(&:default)
           return STATUS_UNAVAILABLE unless endpoint
@@ -49,7 +47,7 @@ module TopologicalInventory
           return STATUS_UNAVAILABLE if endpoint_authentications.empty?
 
           auth_id = endpoint_authentications.first.id
-          auth = Core::AuthenticationRetriever.new(auth_id, nil).process
+          auth = Core::AuthenticationRetriever.new(auth_id, identity).process
           return STATUS_UNAVAILABLE unless auth
 
           connection_manager = TopologicalInventory::Openshift::Connection.new
@@ -59,6 +57,18 @@ module TopologicalInventory
         rescue => e
           logger.error("Failed to connect to Source id:#{source_id} - #{e.message}")
           STATUS_UNAVAILABLE
+        end
+
+        def identity
+          @identity ||= { "x-rh-identity" => Base64.encode64({ "identity" => { "account_number" => params["external_tenant"] }}.to_json) }
+        end
+
+        def api_client
+          @api_client ||= begin
+            api_client = SourcesApiClient::ApiClient.new
+            api_client.default_headers.merge!(identity)
+            SourcesApiClient::DefaultApi.new(api_client)
+          end
         end
       end
     end

--- a/lib/topological_inventory/openshift/operations/source.rb
+++ b/lib/topological_inventory/openshift/operations/source.rb
@@ -1,9 +1,32 @@
+require "sources-api-client"
+
 module TopologicalInventory
   module Openshift
     module Operations
       module Source
         def self.availability_check(params)
-          puts "Running: availability_check for Source id: #{params["source_id"]}"
+          source_id = params["source_id"]
+          raise "Missing source_id for the availability_check request" unless source_id
+
+          # Let's skip the request if it's older than a minute ago.
+          if params["timestamp"]
+            return if params["timestamp"] < (Time.now.utc - 1.minute)
+          end
+
+          puts "Running: availability_check for Source id: #{source_id}"
+
+          api_client = SourcesApiClient::DefaultApi.new
+
+          # TODO: Connection check
+
+          source = SourcesApiClient::Source.new
+          source.availability_status = "available"
+
+          begin
+            api_client.update_source(source_id, source)
+          rescue SourcesApiClient::ApiError => e
+            puts "Failed to update Source id:#{source_id} - #{e}"
+          end
         end
       end
     end

--- a/lib/topological_inventory/openshift/operations/source.rb
+++ b/lib/topological_inventory/openshift/operations/source.rb
@@ -22,11 +22,6 @@ module TopologicalInventory
             return
           end
 
-          # Let's skip the request if it's older than a minute ago.
-          if params["timestamp"]
-            return if params["timestamp"] < (Time.now.utc - 1.minute)
-          end
-
           source = SourcesApiClient::Source.new
           source.availability_status = connection_check(source_id)
 

--- a/lib/topological_inventory/openshift/operations/source.rb
+++ b/lib/topological_inventory/openshift/operations/source.rb
@@ -7,10 +7,11 @@ module TopologicalInventory
         include Logging
         STATUS_AVAILABLE, STATUS_UNAVAILABLE = %w[available unavailable].freeze
 
-        attr_accessor :params, :source_id
+        attr_accessor :params, :context, :source_id
 
-        def initialize(params = {})
-          @params    = params
+        def initialize(params = {}, request_context = nil)
+          @params  = params
+          @context = request_context
           @source_id = nil
         end
 

--- a/lib/topological_inventory/openshift/operations/source.rb
+++ b/lib/topological_inventory/openshift/operations/source.rb
@@ -4,6 +4,8 @@ module TopologicalInventory
   module Openshift
     module Operations
       module Source
+        STATUS_AVAILABLE, STATUS_UNAVAILABLE = %w[available unavailable].freeze
+
         def self.availability_check(params)
           source_id = params["source_id"]
           raise "Missing source_id for the availability_check request" unless source_id
@@ -13,20 +15,37 @@ module TopologicalInventory
             return if params["timestamp"] < (Time.now.utc - 1.minute)
           end
 
-          puts "Running: availability_check for Source id: #{source_id}"
-
           api_client = SourcesApiClient::DefaultApi.new
 
-          # TODO: Connection check
-
           source = SourcesApiClient::Source.new
-          source.availability_status = "available"
+          source.availability_status = connection_check(api_client, source_id)
 
           begin
             api_client.update_source(source_id, source)
           rescue SourcesApiClient::ApiError => e
             puts "Failed to update Source id:#{source_id} - #{e}"
           end
+        end
+
+        def self.connection_check(api_client, source_id)
+          endpoints = api_client.list_source_endpoints(source_id)&.data || []
+          endpoint = endpoints.find(&:default)
+          return STATUS_UNAVAILABLE unless endpoint
+
+          endpoint_authentications = api_client.list_endpoint_authentications(endpoint.id.to_s).data || []
+          return STATUS_UNAVAILABLE if endpoint_authentications.empty?
+
+          auth_id = endpoint_authentications.first.id
+          auth = Core::AuthenticationRetriever.new(auth_id, nil).process
+          return STATUS_UNAVAILABLE unless auth
+
+          connection_manager = TopologicalInventory::Openshift::Connection.new
+          connection_manager.connect("openshift", :host => endpoint.host, :port => endpoint.port, :token => auth.password)
+
+          STATUS_AVAILABLE
+        rescue SourcesApiClient::ApiError => e
+          puts "Failed to connect to Source id:#{source_id} - #{e}"
+          STATUS_UNAVAILABLE
         end
       end
     end

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -34,7 +34,7 @@ module TopologicalInventory
         attr_accessor :messaging_client_opts, :metrics
 
         def process_message(message)
-          model, method = (message.message || message.headers["message_type"]).split(".")
+          model, method = message.message.split(".")
 
           processor = Processor.new(model, method, message.payload, metrics)
           processor.process

--- a/lib/topological_inventory/openshift/operations/worker.rb
+++ b/lib/topological_inventory/openshift/operations/worker.rb
@@ -34,7 +34,7 @@ module TopologicalInventory
         attr_accessor :messaging_client_opts, :metrics
 
         def process_message(message)
-          model, method = message.message.split(".")
+          model, method = (message.message || message.headers["message_type"]).split(".")
 
           processor = Processor.new(model, method, message.payload, metrics)
           processor.process

--- a/spec/topological_inventory/openshift/operations/source_spec.rb
+++ b/spec/topological_inventory/openshift/operations/source_spec.rb
@@ -1,0 +1,34 @@
+require "sources-api-client"
+require "topological_inventory/openshift/operations/source"
+
+RSpec.describe(TopologicalInventory::Openshift::Operations::Source) do
+  describe "availability_check" do
+    let(:host_url) { "https://cloud.redhat.com" }
+    let(:external_tenant) { "11001" }
+    let(:identity) do
+      { "x-rh-identity" => Base64.encode64({ "identity" => { "account_number" => external_tenant } }.to_json) }
+    end
+    let(:headers) { {"Content-Type" => "application/json"}.merge(identity) }
+
+    it "makes a patch request to update the availability_status of a source" do
+      source_id = "201"
+      payload =
+        {
+          "params" => {
+            "source_id"       => source_id,
+            "external_tenant" => external_tenant,
+            "timestamp"       => Time.now.utc
+          }
+        }
+
+      stub_request(:get, "https://cloud.redhat.com/api/sources/v1.0/sources/#{source_id}/endpoints")
+        .with(:headers => headers)
+        .to_return(:status => 200, :body => "", :headers => {})
+      stub_request(:patch, "https://cloud.redhat.com/api/sources/v1.0/sources/#{source_id}")
+        .with(:body => {"availability_status" => "unavailable"}.to_json, :headers => headers)
+        .to_return(:status => 200, :body => "", :headers => {})
+
+      described_class.new(payload["params"]).availability_check
+    end
+  end
+end


### PR DESCRIPTION
Adding support for Source.availability_check

- Framework implementation as TopologicalInventory::Openshift::Operations::\<Model\> module
- methods implemented as a module method taking :payload[:params] as argument
- Added connection check
- Fetching Source endpoints via API
- Updating the source's availability_status via the API

Depends on:
 - [x] https://github.com/ManageIQ/sources-api-client-ruby/pull/5
