### PR TITLE
Operations: Task's context sent as hash

### DIFF
--- a/lib/topological_inventory/openshift/operations/core/topology_api_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/topology_api_client.rb
@@ -13,7 +13,7 @@ module TopologicalInventory
           end
 
           def update_task(task_id, state:, status:, context:)
-            task = TopologicalInventoryApiClient::Task.new("state" => state, "status" => status, "context" => context.to_json)
+            task = TopologicalInventoryApiClient::Task.new("state" => state, "status" => status, "context" => context)
             topology_api_client.update_task(task_id, task)
           end
         end

--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
           :id                => service_instance.id.to_s,
           :url               => "#{base_url_path}service_instances/#{service_instance.id}"
         }
-      }.to_json
+      }
 
       thread = described_class.new("ServicePlan", "order", payload, metrics).process
       thread.join


### PR DESCRIPTION
When updating Task through Topological API, context has to be sent as hash, not as json's string.

**depends on** ManageIQ/topological_inventory-api-client-ruby#15
**depends on** ManageIQ/topological_inventory-api#229