### PR TITLE
Operations: Ordering by service_offering

### DIFF
--- a/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
+++ b/lib/topological_inventory/openshift/operations/core/service_catalog_client.rb
@@ -31,7 +31,7 @@ module TopologicalInventory
             end
           end
 
-          def order_service_plan(plan_name, service_offering_name, additional_parameters)
+          def order_service(plan_name, service_offering_name, additional_parameters)
             payload = build_payload(plan_name, service_offering_name, additional_parameters)
             servicecatalog_connection.create_service_instance(payload)
           end

--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -30,12 +30,16 @@ module TopologicalInventory
         attr_accessor :identity, :model, :method, :metrics, :params
 
         def order_service(params)
-          task_id, service_plan_id, order_params = params.values_at("task_id", "service_plan_id", "order_params")
+          task_id, service_offering_id, service_plan_id, order_params = params.values_at("task_id", "service_offering_id", "service_plan_id", "order_params")
 
-          service_plan     = topology_api_client.show_service_plan(service_plan_id)
-          service_offering = topology_api_client.show_service_offering(service_plan.service_offering_id)
-          source_id        = service_plan.source_id
+          # @deprecated, ordering by service plan will be removed
+          if service_offering_id.nil? && service_plan_id.present?
+            service_plan = topology_api_client.show_service_plan(service_plan_id)
+            service_offering_id = service_plan.service_offering_id
+          end
+          service_offering = topology_api_client.show_service_offering(service_offering_id)
 
+          source_id        = service_offering.source_id
           catalog_client = Core::ServiceCatalogClient.new(source_id, task_id, identity)
 
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...")

--- a/lib/topological_inventory/openshift/operations/processor.rb
+++ b/lib/topological_inventory/openshift/operations/processor.rb
@@ -43,7 +43,7 @@ module TopologicalInventory
           catalog_client = Core::ServiceCatalogClient.new(source_id, task_id, identity)
 
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...")
-          service_instance = catalog_client.order_service_plan(
+          service_instance = catalog_client.order_service(
             service_plan.name, service_offering.name, order_params
           )
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...Complete")

--- a/spec/topological_inventory/openshift/operations/processor_spec.rb
+++ b/spec/topological_inventory/openshift/operations/processor_spec.rb
@@ -87,14 +87,14 @@ RSpec.describe TopologicalInventory::Openshift::Operations::Processor do
         TopologicalInventory::Openshift::Operations::Core::ServiceCatalogClient
       ).to receive(:new).with(source.id, task.id.to_s, identity).and_return(service_catalog_client)
 
-      allow(service_catalog_client).to receive(:order_service_plan).and_return(service_instance)
+      allow(service_catalog_client).to receive(:order_service).and_return(service_instance)
       allow(service_catalog_client).to receive(:wait_for_provision_complete).and_return([service_instance, reason, message])
 
       stub_request(:patch, task_url).with(:headers => headers)
     end
 
     it "orders the service via the service catalog client" do
-      expect(service_catalog_client).to receive(:order_service_plan).with("plan_name", "service_offering", "order_params")
+      expect(service_catalog_client).to receive(:order_service).with("plan_name", "service_offering", "order_params")
       expect(service_catalog_client).to receive(:wait_for_provision_complete).with(service_instance.metadata.name, service_instance.metadata.namespace)
       thread = described_class.new("ServicePlan", "order", payload, metrics).process
       thread.join


### PR DESCRIPTION
ServicePlan.id not needed, but kept for backward compatibility

**dependent**: https://github.com/ManageIQ/topological_inventory-api/pull/235