### PR TITLE
Validation of collector input args

### DIFF
--- a/lib/topological_inventory/openshift/collectors_pool.rb
+++ b/lib/topological_inventory/openshift/collectors_pool.rb
@@ -14,6 +14,15 @@ module TopologicalInventory::Openshift
       File.expand_path("../../../secret", File.dirname(__FILE__))
     end
 
+    def source_valid?(source, secret)
+      missing_data = [source.source,
+                      source.host,
+                      secret["password"]].select do |data|
+        data.to_s.strip.blank?
+      end
+      missing_data.empty?
+    end
+
     def new_collector(source, secret)
       TopologicalInventory::Openshift::Collector.new(source.source, source.host, source.port, secret['password'], metrics)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ end
 require "kubeclient"
 require "rspec"
 require "webmock/rspec"
-require "topological_inventory/openshift/collector"
+require "topological_inventory/openshift/collectors_pool"
 
 RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`

--- a/spec/topological_inventory/openshift/collectors_pool_spec.rb
+++ b/spec/topological_inventory/openshift/collectors_pool_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe TopologicalInventory::Openshift::CollectorsPool do
+  let(:source) { double("Source") }
+
+  subject { described_class.new(nil, nil) }
+
+  describe ".source_valid?" do
+    it "returns false if any of source, host, password are blank" do
+      (-1..2).each do |nil_index|
+        data = (0..2).collect { |j| nil_index == j ? nil : 'some_data' }
+        allow(source).to receive_messages(:source => data[0],
+                                          :host   => data[1])
+        secret = { "username" => nil, "password" => data[2] }
+
+        expect(subject.source_valid?(source, secret)).to eq(nil_index == -1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Input arguments of source in multisource mode are not tested in `bin script`. They should be tested before creating Thread with collector

- [x] **depends on** https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/51