### PR TITLE
Moving collector's common from ingress-api-client-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "manageiq-messaging", "~> 0.1.2"
 gem "sources-api-client",                       :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem 'topological_inventory-api-client',         :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
+gem "topological_inventory-providers-common",   :git => "https://github.com/ManageIQ/topological_inventory-providers-common", :branch => "master"
 
 group :development, :test do
   gem "rspec"

--- a/lib/topological_inventory/openshift/collector.rb
+++ b/lib/topological_inventory/openshift/collector.rb
@@ -1,13 +1,12 @@
 require "concurrent"
-require "topological_inventory-ingress_api-client/collector"
+require "topological_inventory/providers/common/collector"
 require "topological_inventory/openshift"
 require "topological_inventory/openshift/logging"
 require "topological_inventory/openshift/connection"
 require "topological_inventory/openshift/parser"
-require "topological_inventory-ingress_api-client"
 
 module TopologicalInventory::Openshift
-  class Collector < TopologicalInventoryIngressApiClient::Collector
+  class Collector < TopologicalInventory::Providers::Common::Collector
     include Logging
 
     def initialize(source, openshift_host, openshift_port, openshift_token, metrics, default_limit: 500, poll_time: 30)

--- a/lib/topological_inventory/openshift/collectors_pool.rb
+++ b/lib/topological_inventory/openshift/collectors_pool.rb
@@ -1,9 +1,9 @@
-require "topological_inventory-ingress_api-client/collectors_pool"
+require "topological_inventory/providers/common/collectors_pool"
 require "topological_inventory/openshift/collector"
 require "topological_inventory/openshift/logging"
 
 module TopologicalInventory::Openshift
-  class CollectorsPool < TopologicalInventoryIngressApiClient::CollectorsPool
+  class CollectorsPool < TopologicalInventory::Providers::Common::CollectorsPool
     include Logging
 
     def path_to_config

--- a/spec/topological_inventory/openshift/collector_spec.rb
+++ b/spec/topological_inventory/openshift/collector_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
 
       expect { collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid) }.to(
-        raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
+        raise_error(TopologicalInventory::Providers::Common::SaveInventory::Exception::EntityTooLarge)
       )
     end
 
@@ -93,7 +93,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
 
       expect { collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid) }.to(
-        raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
+        raise_error(TopologicalInventory::Providers::Common::SaveInventory::Exception::EntityTooLarge)
       )
     end
 
@@ -107,7 +107,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       expect(client).to receive(:save_inventory_with_http_info).exactly(1).times
 
       expect { collector.send(:save_inventory, parser.collections.values, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, refresh_state_part_uuid) }.to(
-        raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
+        raise_error(TopologicalInventory::Providers::Common::SaveInventory::Exception::EntityTooLarge)
       )
     end
   end
@@ -143,7 +143,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       sweep_scope = {:container_groups => [{:source_ref => "a" * 1_000_002 * multiplier}]}
 
       expect { collector.send(:sweep_inventory, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, 1, sweep_scope) }.to(
-        raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
+        raise_error(TopologicalInventory::Providers::Common::SaveInventory::Exception::EntityTooLarge)
       )
     end
 
@@ -154,7 +154,7 @@ RSpec.describe TopologicalInventory::Openshift::Collector do
       sweep_scope = {:container_groups => (0..1001 * multiplier).map { {:source_ref => "a" * 1_000} } }
 
       expect { collector.send(:sweep_inventory, collector.send(:inventory_name), collector.send(:schema_name), refresh_state_uuid, 1, sweep_scope) }.to(
-        raise_error(TopologicalInventoryIngressApiClient::SaveInventory::Exception::EntityTooLarge)
+        raise_error(TopologicalInventory::Providers::Common::SaveInventory::Exception::EntityTooLarge)
       )
     end
   end


### PR DESCRIPTION
to providers-common gem, because ingress-api-client is built from generator

---

- [x] **depends on** https://github.com/ManageIQ/topological_inventory-providers-common/pull/1