### PR TITLE
Lock down http gem to fix http-parser-ext error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 gem "activesupport", "~> 5.2.2"
 gem "cloudwatchlogger", "~> 0.2"
 gem "concurrent-ruby"
+gem "http", "~> 4.1.1"
 gem "more_core_extensions"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"


### PR DESCRIPTION
```
/usr/local/lib/ruby/gems/2.5.0/gems/ffi-compiler-1.0.1/lib/ffi-compiler/loader.rb:21:in `find': cannot find 'http-parser-ext' library (LoadError)
	from /usr/local/lib/ruby/gems/2.5.0/gems/http-parser-1.2.1/lib/http-parser/ext.rb:8:in `<module:HttpParser>'
	from /usr/local/lib/ruby/gems/2.5.0/gems/http-parser-1.2.1/lib/http-parser/ext.rb:6:in `<top (required)>'
	from /usr/local/lib/ruby/gems/2.5.0/gems/http-parser-1.2.1/lib/http-parser.rb:5:in `require'
	from /usr/local/lib/ruby/gems/2.5.0/gems/http-parser-1.2.1/lib/http-parser.rb:5:in `<top (required)>'
	from /usr/local/lib/ruby/gems/2.5.0/gems/http-4.2.0/lib/http/response/parser.rb:3:in `require'
	from /usr/local/lib/ruby/gems/2.5.0/gems/http-4.2.0/lib/http/response/parser.rb:3:in `<top (required)>'
	from /usr/local/lib/ruby/gems/2.5.0/gems/http-4.2.0/lib/http/connection.rb:6:in `req
```